### PR TITLE
Br wads fix 20210413 1428

### DIFF
--- a/iotconnect-sdk/include/iotconnect.h
+++ b/iotconnect-sdk/include/iotconnect.h
@@ -1,6 +1,7 @@
 //
 // Copyright: Avnet, Softweb Inc. 2020
 // Modified by nmarkovi on 6/15/20.
+// Modified by Alan Low <alan.low@avnet.com> on 4/28/21.
 //
 
 #ifndef IOTCONNECT_H
@@ -29,6 +30,8 @@ typedef enum {
 
 typedef void (*IOT_CONNECT_STATUS_CB)(IOT_CONNECT_STATUS data);
 
+typedef void (*IOT_CONNECT_MSG_ACK_TIMEOUT_CB)(uint32_t msg_id);
+
 typedef struct {
 
     char *env;    // Environment name. Contact your representative for details.
@@ -44,6 +47,7 @@ typedef struct {
     IOTCL_COMMAND_CALLBACK cmd_cb; // callback for command events.
     IOTCL_MESSAGE_CALLBACK msg_cb; // callback for ALL messages, including the specific ones like cmd or ota callback.
     IOT_CONNECT_STATUS_CB status_cb; // callback for connection status
+    IOT_CONNECT_MSG_ACK_TIMEOUT_CB msg_ack_timeout_cb; //callback for message acknowledge timeout.
 } IOTCONNECT_CLIENT_CONFIG;
 
 
@@ -55,11 +59,15 @@ bool IotConnectSdk_IsConnected();
 
 IOTCL_CONFIG *IotConnectSdk_GetLibConfig();
 
-void IotConnectSdk_SendPacket(const char *data);
+bool IotConnectSdk_SendPacket(const char *data, uint32_t *msg_id);
 
 void IotConnectSdk_Loop();
 
 void IotConnectSdk_Disconnect();
+
+int IotConnectSdk_Connect();
+
+int IotConnectSdk_Abort();
 
 #ifdef __cplusplus
 }

--- a/iotconnect-sdk/include/iotconnect.h
+++ b/iotconnect-sdk/include/iotconnect.h
@@ -59,7 +59,7 @@ bool IotConnectSdk_IsConnected();
 
 IOTCL_CONFIG *IotConnectSdk_GetLibConfig();
 
-bool IotConnectSdk_SendPacket(const char *data, uint32_t *msg_id);
+int IotConnectSdk_SendPacket(const char *data, uint32_t *msg_id);
 
 void IotConnectSdk_Loop();
 

--- a/iotconnect-sdk/nrf-layer-lib/include/iotconnect_mqtt.h
+++ b/iotconnect-sdk/nrf-layer-lib/include/iotconnect_mqtt.h
@@ -1,6 +1,7 @@
 //
 // Copyright: Avnet, Softweb Inc. 2020
 // Modified by nmarkovi on 6/15/20.
+// Modified by Alan Low <alan.low@avnet.com> on 4/28/21.
 //
 
 
@@ -18,11 +19,21 @@ extern "C" {
 
 typedef void (*IOT_CONNECT_MQT_ON_DATA_CB)(const uint8_t *data, size_t len, const char *topic);
 
+typedef void (*IOT_CONNECT_MQTT_ON_PUBACK_TIMEOUT_CB)(uint32_t msg_id);
+
+typedef struct {
+
+    uint32_t timeout_s;	// publish acknowledge timeout in seconds.
+    IOT_CONNECT_MQTT_ON_PUBACK_TIMEOUT_CB cb; //callback for publish acknowledge timeout.
+
+} IOTCONNECT_MQTT_PUBACK_TIMEOUT_CONFIG;
+
 typedef struct {
     int tls_verify; // NONE = 0, OPTIONAL = 1, REQUIRED = 2
     const char *env; // Environment name. Contact your representative for details. Same as telemetry config.
     IOT_CONNECT_MQT_ON_DATA_CB data_cb; // callback for OTA events.
     IOT_CONNECT_STATUS_CB status_cb; // callback for command events.
+    IOTCONNECT_MQTT_PUBACK_TIMEOUT_CONFIG puback_timeout_cfg; //puback timeout config.
 } IOTCONNECT_MQTT_CONFIG;
 
 bool iotc_nrf_mqtt_init(IOTCONNECT_MQTT_CONFIG *config, IOTCL_SyncResponse* sr);
@@ -31,7 +42,12 @@ void iotc_nrf_mqtt_loop();
 
 bool iotc_nrf_mqtt_is_connected();
 
-int iotc_nrf_mqtt_publish(struct mqtt_client *c, const char *topic, enum mqtt_qos qos, const uint8_t *data, size_t len);
+int iotc_nrf_mqtt_publish(struct mqtt_client *c, const char *topic, enum mqtt_qos qos, const uint8_t *data, size_t len,
+                            uint32_t *msg_id);
+
+void iotc_nrf_mqtt_disconnect();
+
+void iotc_nrf_mqtt_abort();
 
 #ifdef __cplusplus
 }

--- a/iotconnect-sdk/nrf-layer-lib/src/iotconnect_mqtt.c
+++ b/iotconnect-sdk/nrf-layer-lib/src/iotconnect_mqtt.c
@@ -468,7 +468,7 @@ static void mqtt_evt_handler(struct mqtt_client *const c,
                 break;
             }
 
-            //printk("Packet id: %u acknowledged\n", evt->param.puback.message_id);
+            printk("Packet id: %u acknowledged\n", evt->param.puback.message_id);
 
             //Remove message Id from list if found.
             if (msg_wait_puback_list_find(evt->param.puback.message_id)) {

--- a/iotconnect-sdk/src/iotconnect.c
+++ b/iotconnect-sdk/src/iotconnect.c
@@ -205,12 +205,13 @@ void IotConnectSdk_Disconnect() {
     k_msleep(100);
 }
 
-bool IotConnectSdk_SendPacket(const char *data, uint32_t *msg_id) {
-    if (0 != iotc_nrf_mqtt_publish(&client, sync_response->broker.pub_topic, 1, data, strlen(data), msg_id)) {
+int IotConnectSdk_SendPacket(const char *data, uint32_t *msg_id) {
+    int err;
+    err = iotc_nrf_mqtt_publish(&client, sync_response->broker.pub_topic, 1, data, strlen(data), msg_id);
+    if (0 != err) {
         printk("\n\t Device_Attributes_Data Publish failure");
-        return false;
     }
-    return true;
+    return err;
 }
 
 static void on_message_intercept(IOTCL_EVENT_DATA data, IotConnectEventType type) {

--- a/samples/iotc-basic/src/main.c
+++ b/samples/iotc-basic/src/main.c
@@ -142,10 +142,13 @@ static void nrf_lte_evt_cb(const struct lte_lc_evt *const evt){
 
         case LTE_LC_EVT_CELL_UPDATE:
             printk("Cell id => 0x%08X, Cell tac => 0x%08X\n", evt->cell.id, evt->cell.tac);
-            if (evt->cell.id == 0xFFFFFFFF && lte_link_up) {
+            if (evt->cell.id == 0xFFFFFFFF) {
 
-                lte_link_up = false;
-                printk("LTE network down\n");
+                if (lte_link_up) {
+
+                    lte_link_up = false;
+                    printk("LTE network down\n");
+                }
 
             } else if (!lte_link_up) {
 


### PR DESCRIPTION
Summary of changes
==============
1) iotconnect.c
- Separate IotConnectSdk_Init() to IotConnectSdk_Init() and IotConnectSdk_Connect().
    - IotConnectSdk_Init() => Perform discover only.
    - IotConnectSdk_Connect() => Perform connection to MQTT broker.
 
- Added IotConnectSdk_Abort() function. iotc_nrf_mqtt_abort() is invoked in this function to disconnect MQTT broker locally.
- Modify IotConnectSdk_SendPacket() to add a unsigned long pointer to receive the message Id. Main application can use this message id to track the message sent when acknowledge timeout event occurred.

2) iotconnect.h
- Added declaration for IotConnectSdk_Connect() and IotConnectSdk_Abort().
- Modify IotConnectSdk_SendPacket() to take in unsigned long pointer as 2nd parameter.
- Modify IOTCONNECT_CLIENT_CONFIG structure to add a callback pointer for message acknowledge timeout event.

3) iotconnect_mqtt.c
- Added iotc_nrf_mqtt_abort() to invoke mqtt_abort() to disconnect MQTT broker locally.
- Added helper functions to keep track of message acknowledge timeout and trigger callback function when no PUBACK received for the specific message id after 5 seconds.

4) iotconnect_mqtt.h
- Added declaration for iotc_nrf_mqtt_abort().

5) main.c from iotc-basic
- Modified to have the following features:
    - montior LTE registration and cell status.
        - When detected LTE link down, IotConnectSdk_Abort() is invoked to disconnect the MQTT broker locally.
        - When detected LTE resume, IotConnectSdk_Connect() is invoked to re-connect back to MQTT broker and resume sending of telemetry data.
....- Added message acknowledge timeout event handler to print out acknowledge time message for which message id.

6) main.c from iotc-sensors-gps
- Modified the sdk_run() to connect to MQTT broker using IotConnectSdk_Connect().
- Modified IotConnectSdk_SendPacket() to have 2nd parameter as NULL.