### PR TITLE
Br 20210517 0934

### DIFF
--- a/iotconnect-sdk/include/iotconnect.h
+++ b/iotconnect-sdk/include/iotconnect.h
@@ -54,6 +54,8 @@ void iotconnect_sdk_loop();
 
 void iotconnect_sdk_disconnect();
 
+int iotconnect_sdk_abort();
+
 #ifdef __cplusplus
 }
 #endif

--- a/iotconnect-sdk/nrf-layer-lib/include/iotconnect_mqtt.h
+++ b/iotconnect-sdk/nrf-layer-lib/include/iotconnect_mqtt.h
@@ -33,6 +33,8 @@ bool iotc_nrf_mqtt_is_connected();
 
 int iotc_nrf_mqtt_publish(struct mqtt_client *c, const char *topic, enum mqtt_qos qos, const uint8_t *data, size_t len);
 
+void iotc_nrf_mqtt_abort();
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
[Changes summary]

iotconnect.h
- Added function declaration for iotconnect_sdk_abort().

iotconnect.c
- Modified iotconnect_sdk_init() to ensure the function only perform discovery process once.
- Added iotconnect_sdk_abort() function to disconnect MQTT broker locally.

iotconnect_mqtt.h
- Added function declaration for iotc_nrf_mqtt_abort().

iotconnect_mqtt.c
- Modified get_next_message_id() to reset rolling_message_id to 1 instead of 0.
- Modified iotc_nrf_mqtt_publish() function to re-send the message if it does not received PUBACK message for more than 5 seconds. A Mutex is added to prevent other thread from calling iotc_nrf_mqtt_publish() at the same time.
- Added checking and informing iotc_nrf_mqtt_publish() of receiving current pending message acknowledgement in the mqtt_evt_handler().
- Added iotc_nrf_mqtt_abort() function to execute mqtt_abort().

iotc_basic/main.c
- Added print_lte_lc_evt_string() to print the LTE link connection event string. It can be enabled/disabled by PRINT_LTE_LC_EVENTS definition switch.
- Added nrf_lte_evt_cb() to receive all LTE related information and determine the current LTE link connectivity status.
- Added lte_link_and_connection_handler() to handle MQTT disconnection when LTE link is down and MQTT re-connection when LTE link is up.
- Modify sdk_run() to merge lte_link_and_connection_handler() to the run loop.
