### PR TITLE
Br 20211004 1031

### DIFF
--- a/iotconnect-sdk/include/iotconnect.h
+++ b/iotconnect-sdk/include/iotconnect.h
@@ -26,6 +26,13 @@ typedef enum {
     // TODO: Sync statuses etc.
 } IotconnectConnectionStatus;
 
+typedef enum {
+    MSG_SEND_SUCCESS, //Received PUBACK for the respective message.
+    MSG_SEND_TIMEOUT, //Message drop from queue due to maximum retry with PUBACK timeout.
+    MSG_SEND_FAILED,  //Message drop from queue due to disconnection. 
+} IotconnectMsgSendStatus;
+
+typedef void (*IotConnectMsgSendStatusCallback)(uint32_t msg_id, IotconnectMsgSendStatus status);
 
 typedef void (*IotConnectStatusCallback)(IotconnectConnectionStatus data);
 
@@ -37,6 +44,7 @@ typedef struct {
     IotclCommandCallback cmd_cb; // callback for command events.
     IotclMessageCallback msg_cb; // callback for ALL messages, including the specific ones like cmd or ota callback.
     IotConnectStatusCallback status_cb; // callback for connection status
+    IotConnectMsgSendStatusCallback msg_send_status_cb; // callback for MQTT message send status.
 } IotconnectClientConfig;
 
 
@@ -48,7 +56,7 @@ bool iotconnect_sdk_is_connected();
 
 IotclConfig *iotconnect_sdk_get_lib_config();
 
-void iotconnect_sdk_send_packet(const char *data);
+void iotconnect_sdk_send_packet(const char *data, uint32_t *p_msg_id);
 
 void iotconnect_sdk_loop();
 

--- a/iotconnect-sdk/nrf-layer-lib/include/iotconnect_mqtt.h
+++ b/iotconnect-sdk/nrf-layer-lib/include/iotconnect_mqtt.h
@@ -23,6 +23,7 @@ typedef struct {
     const char *env; // Environment name. Contact your representative for details. Same as telemetry config.
     IotconnectMqttOnDataCallback data_cb; // callback for OTA events.
     IotConnectStatusCallback status_cb; // callback for command events.
+    IotConnectMsgSendStatusCallback msg_send_status_cb;  // callback for message send status.
 } IotconnectMqttConfig;
 
 bool iotc_nrf_mqtt_init(IotconnectMqttConfig *config, IotclSyncResponse *sr);
@@ -31,7 +32,8 @@ void iotc_nrf_mqtt_loop();
 
 bool iotc_nrf_mqtt_is_connected();
 
-int iotc_nrf_mqtt_publish(struct mqtt_client *c, const char *topic, enum mqtt_qos qos, const uint8_t *data, size_t len);
+int iotc_nrf_mqtt_publish(struct mqtt_client *c, const char *topic, enum mqtt_qos qos, const uint8_t *data,
+                            size_t len, uint32_t *p_msg_id);
 
 void iotc_nrf_mqtt_abort();
 

--- a/iotconnect-sdk/src/iotconnect.c
+++ b/iotconnect-sdk/src/iotconnect.c
@@ -211,7 +211,7 @@ void iotconnect_sdk_disconnect() {
 // being sent.
 void iotconnect_sdk_send_packet(const char *data, uint32_t *p_msg_id) {
     if (0 != iotc_nrf_mqtt_publish(&client, sync_response->broker.pub_topic, MQTT_QOS_1_AT_LEAST_ONCE, data, strlen(data),
-    	p_msg_id)) {
+    ....p_msg_id)) {
         printk("\n\t Device_Attributes_Data Publish failure");
     }
 }

--- a/iotconnect-sdk/src/iotconnect.c
+++ b/iotconnect-sdk/src/iotconnect.c
@@ -193,7 +193,11 @@ static void on_iotconnect_status(IotconnectConnectionStatus status) {
     }
 }
 
-
+static void on_msg_send_status(uint32_t msg_id, IotconnectMsgSendStatus status) {
+    if (config.msg_send_status_cb) {
+        config.msg_send_status_cb(msg_id, status);
+    }
+}
 ///////////////////////////////////////////////////////////////////////////////////
 // Get All twin property from C2D
 void iotconnect_sdk_disconnect() {
@@ -202,8 +206,12 @@ void iotconnect_sdk_disconnect() {
     k_msleep(100);
 }
 
-void iotconnect_sdk_send_packet(const char *data) {
-    if (0 != iotc_nrf_mqtt_publish(&client, sync_response->broker.pub_topic, MQTT_QOS_0_AT_MOST_ONCE, data, strlen(data))) {
+// Send MQTT message.
+// p_msg_id points to a 32-bit variable that store the assigned message id of the message
+// being sent.
+void iotconnect_sdk_send_packet(const char *data, uint32_t *p_msg_id) {
+    if (0 != iotc_nrf_mqtt_publish(&client, sync_response->broker.pub_topic, MQTT_QOS_1_AT_LEAST_ONCE, data, strlen(data),
+    	p_msg_id)) {
         printk("\n\t Device_Attributes_Data Publish failure");
     }
 }
@@ -302,6 +310,7 @@ int iotconnect_sdk_init() {
     mqtt_config.tls_verify = CONFIG_PEER_VERIFY;
     mqtt_config.data_cb = iotc_on_mqtt_data;
     mqtt_config.status_cb = on_iotconnect_status;
+    mqtt_config.msg_send_status_cb = on_msg_send_status;
 
     if (!iotc_nrf_mqtt_init(&mqtt_config, sync_response)) {
         return -8;

--- a/samples/iotc-sensors-gps/src/command_handling.c
+++ b/samples/iotc-sensors-gps/src/command_handling.c
@@ -17,7 +17,7 @@ void command_status(IotclEventData data, bool status, const char *command_name, 
     const char *ack = iotcl_create_ack_string_and_destroy_event(data, status, message);
     printk("command: %s status=%s: %s\n", command_name, status ? "OK" : "Failed", message);
     printk("Sent CMD ack: %s\n", ack);
-    iotconnect_sdk_send_packet(ack);
+    iotconnect_sdk_send_packet(ack, NULL);
     free((void *) ack);
 }
 


### PR DESCRIPTION
[iotconnect-sdk/nrf-layer-lib/src/iotconnect_mqtt.c]
- Remove blocking codes from iotc_nrf_mqtt_publish() to resolve deadlock issue.
- Return assigned message id for the message send from iotc_nrf_mqtt_publish(). 
- Implement message queue for messages with QOS 1 on the followings:
  - Add new message send to message queue.
  - Fire user callback with MSG_SEND_SUCCESS and remove message from queue when the message PUBACK is received.
  - Check all pending message timeout and perform re-send if needed in the iotc_nrf_mqtt_loop().
  - Fire user callback with MSG_SEND_TIMEOUT when pending message timeout and re-send count expired.
  - Clear message queue and fire user callback with MSG_SEND_FAILED when MQTT disconnected.

[iotconnect-sdk/src/iotconnect.c]
- Modify iotconnect_sdk_send_packet() to returned assigned message id for the message send.
 
[iotconnect-sdk/include/iotconnect.h]
- Add IotconnectMsgSendStatus type define.
- Add IotConnectMsgSendStatusCallback() function type define.
- Modify iotconnect_sdk_send_packet() declaration to return assigned message id for the message send.

[iotconnect-sdk/nrf-layer-lib/include/iotconnect_mqtt.h]
- Add IotConnectMsgSendStatusCallback function pointer to IotconnectMqttConfig type define.
- Modify iotc_nrf_mqtt_publish() declaration to return assigned message id for the message send.

[samples/iotc-basic/src/main.c]
- Add message send status callback function to receive message send status from iotconnect sdk lib.
- Modify app to wait for PUBACK for last telemetry message send before sending the next one.

[samples/iotc-sensors-gps/src/main.c]
- Add message send status callback function to receive message send status from iotconnect sdk lib.
- Modify app to wait for PUBACK for last telemetry message send before sending the next one.

[samples/iotc-sensors-gps/src/command_handling.c]
- Update changes to iotconnect_sdk_send_packet().