### PR TITLE
Boolean function always returns non-zero integer, i.e. always convert…

### DIFF
--- a/iotconnect-sdk/nrf-layer-lib/src/iotconnect_mqtt.c
+++ b/iotconnect-sdk/nrf-layer-lib/src/iotconnect_mqtt.c
@@ -434,22 +434,22 @@ bool iotc_nrf_mqtt_init(IotconnectMqttConfig *c, IotclSyncResponse *sr) {
     config = c;
 
     if (!client_init()) {
-        return -1;
+        return false;
     }
 
     err = mqtt_connect(&client);
     if (err != 0) {
         printk("ERROR: mqtt_connect %d\n", err);
-        return -2;
+        return false;
     }
 
     err = fds_init(&client);
     if (err != 0) {
         printk("ERROR: fds_init %d\n", err);
-        return -3;
+        return false;
     }
 
-    return 1;
+    return true;
 
 }
 


### PR DESCRIPTION
…s to true - even when it's an apparent failure.

Untested / QA'd.

NOTE THIS IS A CHANGE IN BEHAVIOUR -- even if it is only a change on an error path!